### PR TITLE
fix(CreateGroupLanding.jsx) : 완료 버튼과 footer 겹치는 문제 해결

### DIFF
--- a/client-quota/src/components/teams/createForm/CreateGroupLanding.jsx
+++ b/client-quota/src/components/teams/createForm/CreateGroupLanding.jsx
@@ -21,7 +21,6 @@ const CreateGroupFormContainer = styled.div`
     display: flex;
     justify-content: center;
     align-items: center;
-    height: 100vh;
 `;
 
 const GroupFormContainer = styled.div`


### PR DESCRIPTION
## 📝 PR 전 확인! 📝
PR이 다음 요구 사항을 충족하는지 확인하세요. :

- [x] 커밋 메시지가 [다음 지침](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit)과 O1B4의 룰에 따르나요? 
- [x] 로컬 및 실 서버에서 테스트를 진행했나요?(버그 해결 / 기능)


## PR 종류
해당 PR은 어떤 부분에 대한 변화인가요

<!-- Please check the one that applies to this PR using "x". -->

- [x] 버그 수정 `FIX`(Hotfix)
- [x] 코드 수정 `MODIFY`
- [ ] 기능 추가 `FEAT`
- [ ] 파일 이름 변경 `RENAME`
- [ ] 테스트 코드 추가 `TEST`
- [ ] 코드 스타일 변화 (formatting, local variables) `STYLE`
- [ ] 리팩토링 (no functional changes, no api changes) `REFACTOR`
- [ ] 빌드 관련 내용 추가 및 변화 `BUILD`
- [ ] 문서 내용 추가 및 변화`DOCS`
- [ ] 기타 변경 사항 추 `CHORE`
- [ ] Other... (적어주세요 : ) 


## 현재 작업 이슈를 연결해주세요
<!-- 수정하려는 현재 동작을 설명하거나 관련 문제에 대한 링크를 제공하십시오. -->
> Issue Number: #1


## 직전 버전과 비교하여 새롭게 추가된 혹은 변경된 점은 무엇인가요?
- 완료 버튼과 footer 겹치는 문제 해결


## 해당 PR이 다른 영역에 영향을 미치나요?

- [ ] Yes
- [x] No


<!-- "Yes"를 선택한 경우, 어떤 영향을 끼치는지, 발생 위치 Path를 설명해주세요. -->


## 추가 정보
<img width="1507" alt="스크린샷 2023-12-19 오후 8 06 36" src="https://github.com/O1B4/Client-Quota/assets/114149212/650ecd06-76d8-4e3e-abe2-c2260e414220">
-> 기존에 화면이 작아지면 생기던 문제점

<img width="1792" alt="스크린샷 2023-12-19 오후 8 06 08" src="https://github.com/O1B4/Client-Quota/assets/114149212/eba6e2ea-9367-4d93-a85c-f5d20d943799">
-> 전체 화면

<img width="1507" alt="스크린샷 2023-12-19 오후 8 06 32" src="https://github.com/O1B4/Client-Quota/assets/114149212/68c71846-70a8-4c82-93d8-d07195efcc98">
-> 화면 작아진 후